### PR TITLE
Let materializeRecords return more useful, destructurable object

### DIFF
--- a/dist/vuex-jsonapi.cjs.js
+++ b/dist/vuex-jsonapi.cjs.js
@@ -4485,19 +4485,22 @@ class Store {
    * Materializes and returns records from an HTTP response body
    *
    * @param data
-   * @returns {Record|Record[]}
+   * @returns {{data: Array, response: *, meta, included: Array}}
    */
 
 
   materializeRecords(data) {
-    // If HTTP response and included is found, materialize all included records first so they're available to the
+    let response = data; // If HTTP response and included is found, materialize all included records first so they're available to the
     // main records
+
+    let included = [];
+
     if (data && data.data && data.data.included) {
-      this.materializeRecords(data.data.included);
+      included = this.materializeRecords(data.data.included).data;
     } // Capture the meta
 
 
-    let meta = null;
+    let meta = {};
 
     if (data && data.data && data.data.meta) {
       meta = data.data.meta;
@@ -4525,14 +4528,14 @@ class Store {
       ret.push(record);
     }); // Transform back to response data format
 
-    ret = single ? ret[0] : ret; // Append the meta (if applicable)
+    ret = single ? ret[0] : ret; // Send it on
 
-    if (meta) {
-      ret.meta = meta;
-    } // Send it on
-
-
-    return ret;
+    return {
+      response,
+      data: ret,
+      included,
+      meta
+    };
   }
   /**
    * Serializes record into server-friendly body
@@ -4934,22 +4937,25 @@ var actions = ((apiClient, store) => {
         channel,
         value: false
       });
-      apiClient.find(type, id, params).then(records => {
+      apiClient.find(type, id, params).then(({
+        data,
+        meta
+      }) => {
         commit('updateChannel', {
           channel,
-          value: records
+          value: data
         });
         commit('updateMeta', {
           channel,
-          value: records.meta || {}
+          value: meta
         });
         commit('updateMoreRecords', {
           channel,
-          value: get(records, 'meta.record_count') > records.length
+          value: meta.record_count > data.length
         });
         commit('updateNoRecords', {
           channel,
-          value: records.length === 0
+          value: data.length === 0
         });
       }).catch(error => {
         let requestError = new RequestError(error, {
@@ -4981,8 +4987,11 @@ var actions = ((apiClient, store) => {
       let persisted = record._persisted;
       apiClient.save(record, {
         params
-      }).then(record => {
-        // Notify of save/create/update
+      }).then(({
+        data
+      }) => {
+        let record = data; // Notify of save/create/update
+
         this._vm.$emit('didSaveRecord', {
           record,
           suppress: suppress || suppressSuccess
@@ -5084,7 +5093,7 @@ var actions = ((apiClient, store) => {
       });
       commit('updateChannel', {
         channel,
-        value: store.materializeRecords(records)
+        value: store.materializeRecords(records).data
       });
     }
 
@@ -5215,7 +5224,7 @@ var mapChannel = ((channel, name = null) => {
 });
 
 var index_esm = {
-  version: '0.1.0',
+  version: '0.2.0',
   Client,
   Record,
   Store,

--- a/src/core/store.js
+++ b/src/core/store.js
@@ -43,17 +43,20 @@ class Store {
    * Materializes and returns records from an HTTP response body
    *
    * @param data
-   * @returns {Record|Record[]}
+   * @returns {{data: Array, response: *, meta, included: Array}}
    */
   materializeRecords(data) {
+    let response = data;
+
     // If HTTP response and included is found, materialize all included records first so they're available to the
     // main records
+    let included = [];
     if (data && data.data && data.data.included) {
-      this.materializeRecords(data.data.included);
+      included = this.materializeRecords(data.data.included).data;
     }
 
     // Capture the meta
-    let meta = null;
+    let meta = {};
     if (data && data.data && data.data.meta) {
       meta = data.data.meta;
     }
@@ -82,13 +85,13 @@ class Store {
     // Transform back to response data format
     ret = single ? ret[0] : ret;
 
-    // Append the meta (if applicable)
-    if (meta) {
-      ret.meta = meta;
-    }
-
     // Send it on
-    return ret;
+    return {
+      response,
+      data: ret,
+      included,
+      meta,
+    };
   }
 
   /**

--- a/src/extensions/actions.js
+++ b/src/extensions/actions.js
@@ -16,11 +16,11 @@ export default (apiClient, store) => {
       commit('updateNoRecords', { channel, value: false });
       apiClient
         .find(type, id, params)
-        .then(records => {
-          commit('updateChannel', { channel, value: records });
-          commit('updateMeta', { channel, value: records.meta || {} });
-          commit('updateMoreRecords', { channel, value: get(records, 'meta.record_count') > records.length });
-          commit('updateNoRecords', { channel, value: records.length === 0 });
+        .then(({ data, meta }) => {
+          commit('updateChannel', { channel, value: data });
+          commit('updateMeta', { channel, value: meta });
+          commit('updateMoreRecords', { channel, value: meta.record_count > data.length });
+          commit('updateNoRecords', { channel, value: data.length === 0 });
         })
         .catch(error => {
           let requestError = new RequestError(error, { suppress });
@@ -35,7 +35,9 @@ export default (apiClient, store) => {
       let persisted = record._persisted;
       apiClient
         .save(record, { params })
-        .then(record => {
+        .then(({ data }) => {
+          let record = data;
+
           // Notify of save/create/update
           this._vm.$emit('didSaveRecord', { record, suppress: suppress || suppressSuccess });
           this._vm.$emit(persisted ? 'didUpdateRecord' : 'didCreateRecord', { record, suppress: suppress || suppressSuccess });
@@ -75,7 +77,7 @@ export default (apiClient, store) => {
     },
     materialize({ dispatch, commit }, { records, channel }) {
       dispatch('clear', { channel });
-      commit('updateChannel', { channel, value: store.materializeRecords(records) });
+      commit('updateChannel', { channel, value: store.materializeRecords(records).data });
     }
   };
 }


### PR DESCRIPTION
(to give access to meta, included, data, and response)